### PR TITLE
Implement service to render SVG and PNG from vega specification

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Service to render a Vega specification to PNG/SVG
+
+var express = require('express'),
+  vg = require("../index");
+
+var port = process.argv[2] || 8888,
+  app = express(),
+  svgHeader =
+	  '<?xml version="1.0" encoding="utf-8"?>\n' +
+	  '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" ' +
+	  '"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n';
+
+app.use(function(req, res, next) {
+    var data = '';
+    req.setEncoding('utf8');
+    req.on('data', function(chunk) {
+       data += chunk;
+    });
+
+    req.on('end', function() {
+        req.body = data;
+        next();
+    });
+});
+
+// Render vega specification as PNG.
+app.post('/vg2png', function (req, res) {
+  console.log("Rendering a PNG");
+
+  var spec = JSON.parse(req.body);
+
+  res.set('Content-Type', 'image/png');
+
+  vg.headless.render(
+    {spec: spec, renderer: "canvas"},
+    function(err, data) {
+      if (err) throw err;
+      var stream = data.canvas.createPNGStream();
+  	  stream.on("data", function(chunk) { res.write(chunk); }).on("end", function() { res.end(); });
+    }
+  );
+});
+
+// Render vega specification as SVG. Set header to true to include XML header and SVG doctype
+app.post('/vg2svg', function (req, res) {
+  console.log("Rendering an SVG");
+
+  var spec = JSON.parse(req.body);
+
+  res.set('Content-Type', 'image/svg+xml');
+
+  // include xml header
+  var header = req.param("header", "false") === "true";
+
+  vg.headless.render(
+    {spec: spec, renderer:"svg"},
+    function(err, data) {
+      if (err) throw err;
+      res.send((header ? svgHeader : "") + data.svg);
+    }
+  );
+});
+
+var server = app.listen(port, function () {
+  var host = server.address().address;
+  var port = server.address().port;
+
+  console.log("Server listening at http://%s:%s", host, port);
+});

--- a/bin/server
+++ b/bin/server
@@ -7,9 +7,9 @@ var express = require('express'),
 var port = process.argv[2] || 8888,
   app = express(),
   svgHeader =
-	  '<?xml version="1.0" encoding="utf-8"?>\n' +
-	  '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" ' +
-	  '"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n';
+      '<?xml version="1.0" encoding="utf-8"?>\n' +
+      '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" ' +
+      '"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n';
 
 app.use(function(req, res, next) {
     var data = '';
@@ -27,31 +27,30 @@ app.use(function(req, res, next) {
 // Render vega specification as PNG.
 app.post('/vg2png', function (req, res) {
   console.log("Rendering a PNG");
+  res.set('Content-Type', 'image/png');
 
   var spec = JSON.parse(req.body);
-
-  res.set('Content-Type', 'image/png');
 
   vg.headless.render(
     {spec: spec, renderer: "canvas"},
     function(err, data) {
       if (err) throw err;
       var stream = data.canvas.createPNGStream();
-  	  stream.on("data", function(chunk) { res.write(chunk); }).on("end", function() { res.end(); });
+      stream
+        .on("data", function(chunk) { res.write(chunk); })
+        .on("end", function() { res.end(); });
     }
   );
 });
 
-// Render vega specification as SVG. Set header to true to include XML header and SVG doctype
+// Render vega specification as SVG.
+// Set `header` to `true` to include XML header and SVG doctype
 app.post('/vg2svg', function (req, res) {
   console.log("Rendering an SVG");
-
-  var spec = JSON.parse(req.body);
-
   res.set('Content-Type', 'image/svg+xml');
 
-  // include xml header
-  var header = req.param("header", "false") === "true";
+  var spec = JSON.parse(req.body),
+    header = req.param("header", "false") === "true";
 
   vg.headless.render(
     {spec: spec, renderer:"svg"},

--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
   "main": "index.js",
   "bin": {
     "vg2png": "./bin/vg2png",
-    "vg2svg": "./bin/vg2svg"
+    "vg2svg": "./bin/vg2svg",
+    "server": "./bin/server"
   },
   "dependencies": {
     "d3": "3.4.10",
     "canvas": "1.1.3",
     "optimist": "0.6.1",
     "topojson": "1.6.14",
-    "d3-geo-projection": "0.2.10"
+    "d3-geo-projection": "0.2.10",
+    "express": "4.10.4"
   },
   "devDependencies": {
     "uglify-js": "2.4.13",


### PR DESCRIPTION
To run the server, use `node bin/server`.

To use the server, run `url -v -X POST -d @./examples/spec/bar.json http://localhost:8888/vg2png`.

Currently, the data has to be included in the request. 