### PR TITLE
Fix reverse

### DIFF
--- a/src/parse/scales.js
+++ b/src/parse/scales.js
@@ -192,7 +192,7 @@ vg.parse.scales = (function() {
           return rng;
         }
       } else if (vg.isArray(def.range)) {
-        rng = def.range;
+        rng = vg.duplicate(def.range);
       } else if (vg.isObject(def.range)) {
         return null; // early exit
       } else {


### PR DESCRIPTION
Copy the range because reverse is in place and calling domainMinMax multiple times undoes reverse.

In my spec that uses auto padding and reverse, the reverse does not have an effect because it is undone. 