### PR TITLE
bump canvas to 1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "d3": "^3.5.5",
     "d3-geo-projection": "^0.2.13",
-    "canvas": "~1.1.6",
+    "canvas": "^1.2",
     "topojson": "^1.6.18",
     "yargs": "^2.3.0",
     "request": "2.53.0"


### PR DESCRIPTION
This bumps the node canvas dependency to 1.2.x, which allows us to run on io.js