### PR TITLE
Null values shouldn’t be parsed to number or bool

### DIFF
--- a/src/_package.js
+++ b/src/_package.js
@@ -40,6 +40,8 @@ vg.number = function(s) { return s === null ? null : +s; };
 
 vg.boolean = function(s) { return s === null ? null :  !!s; };
 
+vg.date = function(s) {return s === null ? null : Date.parse(s); }
+
 // ES6 compatibility per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#Polyfill
 // We could have used the polyfill code, but lets wait until ES6 becomes a standard first
 vg.startsWith = String.prototype.startsWith ?

--- a/src/_package.js
+++ b/src/_package.js
@@ -36,9 +36,9 @@ vg.tree = function(obj, children) {
   return d;
 };
 
-vg.number = function(s) { return +s; };
+vg.number = function(s) { return s === null ? null : +s; };
 
-vg.boolean = function(s) { return !!s; };
+vg.boolean = function(s) { return s === null ? null :  !!s; };
 
 // ES6 compatibility per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#Polyfill
 // We could have used the polyfill code, but lets wait until ES6 becomes a standard first

--- a/src/data/read.js
+++ b/src/data/read.js
@@ -3,7 +3,7 @@ vg.data.read = (function() {
       parsers = {
         "number": vg.number,
         "boolean": vg.boolean,
-        "date": Date.parse
+        "date": vg.date
       };
 
   function read(data, format) {


### PR DESCRIPTION
The current behavior doesn't let us filter out null values after parsing the data with a particular type. 